### PR TITLE
Extract constants for _render_horizon_view method

### DIFF
--- a/src/widgets/calendar_widget.py
+++ b/src/widgets/calendar_widget.py
@@ -1,7 +1,7 @@
 """Adaptive calendar widget that intelligently fits all events without truncation."""
 
-from datetime import datetime, timedelta, date, time as time_class
-from typing import List, Dict, Tuple
+from datetime import datetime, timedelta, date, time as time_class, time
+from typing import List, Dict, Tuple, Any
 
 from src.display.display_interface import DisplayInterface
 from src.widgets.widget_interface import WidgetInterface
@@ -810,31 +810,7 @@ class CalendarWidget(WidgetInterface):
         PRIORITY: Show ALL upcoming events - no surprises.
         Past events minimized but visible.
         """
-        now = datetime.now()
-        current_time = now.time()
-        today = now.date()
-        tomorrow = today + timedelta(days=1)
-
-        # Get events for today and tomorrow
-        events = self.calendar_service.get_events(
-            start_date=today, end_date=tomorrow + timedelta(days=1)
-        )
-
-        # Separate today's and tomorrow's events
-        today_events = []
-        tomorrow_events = []
-
-        for e in events:
-            event_date = e["date"]
-            if hasattr(event_date, "date"):
-                event_date = event_date.date()
-            elif isinstance(event_date, str):
-                event_date = datetime.strptime(event_date, "%Y-%m-%d").date()
-
-            if event_date == today:
-                today_events.append(e)
-            elif event_date == tomorrow:
-                tomorrow_events.append(e)
+        current_time, now, today_events, tomorrow_events = self._fetch_horizon_events()
 
         # Categorize today's events by time
         past_events = []
@@ -990,6 +966,40 @@ class CalendarWidget(WidgetInterface):
                 y_past_start += 18
 
         return y
+
+    def _fetch_horizon_events(self) -> tuple[list[Any], time, datetime, list[Any]]:
+        """
+        Fetch events for today and tomorrow, separated by day.
+
+        Returns:
+            tuple(now, current_time, today, tomorrow, today_events, tomorrow_events)
+        """
+        now = datetime.now()
+        current_time = now.time()
+        today = now.date()
+        tomorrow = today + timedelta(days=1)
+
+        # Get events for today and tomorrow
+        events = self.calendar_service.get_events(
+            start_date=today, end_date=tomorrow + timedelta(days=1)
+        )
+
+        # Separate today's and tomorrow's events
+        today_events = []
+        tomorrow_events = []
+
+        for e in events:
+            event_date = e["date"]
+            if hasattr(event_date, "date"):
+                event_date = event_date.date()
+            elif isinstance(event_date, str):
+                event_date = datetime.strptime(event_date, "%Y-%m-%d").date()
+
+            if event_date == today:
+                today_events.append(e)
+            elif event_date == tomorrow:
+                tomorrow_events.append(e)
+        return current_time, now, today_events, tomorrow_events
 
     def _render_event_line_with_time_until(
         self, display, x_offset, y_offset, event, now

--- a/src/widgets/calendar_widget.py
+++ b/src/widgets/calendar_widget.py
@@ -813,27 +813,9 @@ class CalendarWidget(WidgetInterface):
         current_time, now, today_events, tomorrow_events = self._fetch_horizon_events()
 
         # Categorize today's events by time
-        past_events = []
-        happening_now = []
-        upcoming_today = []
-        all_day_events = []
-
-        for event in today_events:
-            event_time_str = event["time"]
-
-            if event_time_str == "All Day":
-                all_day_events.append(event)
-            else:
-                event_time = self._parse_time(event_time_str)
-                if event_time:
-                    event_end = self._get_event_end_time(event, event_time)
-
-                    if event_end < current_time:
-                        past_events.append(event)
-                    elif event_time <= current_time < event_end:
-                        happening_now.append(event)
-                    else:
-                        upcoming_today.append(event)
+        all_day_events, happening_now, past_events, upcoming_today = (
+            self._categorize_events_by_time(current_time, today_events)
+        )
 
         # Calculate space budget
         y = y_offset + self.padding
@@ -966,6 +948,32 @@ class CalendarWidget(WidgetInterface):
                 y_past_start += 18
 
         return y
+
+    def _categorize_events_by_time(
+        self, current_time: list[Any], today_events: datetime
+    ) -> tuple[list[Any], list[Any], list[Any], list[Any]]:
+        past_events = []
+        happening_now = []
+        upcoming_today = []
+        all_day_events = []
+
+        for event in today_events:
+            event_time_str = event["time"]
+
+            if event_time_str == "All Day":
+                all_day_events.append(event)
+            else:
+                event_time = self._parse_time(event_time_str)
+                if event_time:
+                    event_end = self._get_event_end_time(event, event_time)
+
+                    if event_end < current_time:
+                        past_events.append(event)
+                    elif event_time <= current_time < event_end:
+                        happening_now.append(event)
+                    else:
+                        upcoming_today.append(event)
+        return all_day_events, happening_now, past_events, upcoming_today
 
     def _fetch_horizon_events(self) -> tuple[list[Any], time, datetime, list[Any]]:
         """

--- a/src/widgets/calendar_widget.py
+++ b/src/widgets/calendar_widget.py
@@ -6,9 +6,33 @@ from typing import List, Dict, Tuple
 from src.display.display_interface import DisplayInterface
 from src.widgets.widget_interface import WidgetInterface
 
-EVENTS_THRESHOLD_MEDIUM = 12
+# Layout dimensions
+DEFAULT_WIDTH = 480
+DEFAULT_HEIGHT = 350
+DEFAULT_PADDING = 20
 
+# Spacing between days
+SPACING_COMFORTABLE = 16
+SPACING_MEDIUM = 14
+SPACING_COMPACT = 12
+
+# Font size for different event densities
+FONT_SIZE_HEADER_SMALL = 13
+FONT_SIZE_HEADER_MEDIUM = 14
+FONT_SIZE_HEADER_LARGE = 15
+
+FONT_SIZE_EVENT_LARGE = 14
+FONT_SIZE_EVENT_MEDIUM = 13
+FONT_SIZE_EVENT_SMALL = 12
+
+# Line heights
+LINE_HEIGHT_COMPACT = 16
+LINE_HEIGHT_NORMAL = 18
+LINE_HEIGHT_COMFORTABLE = 20
+
+# Event count thresholds for adaptive sizing
 EVENTS_THRESHOLD_SMALL = 6
+EVENTS_THRESHOLD_MEDIUM = 12
 
 
 class CalendarWidget(WidgetInterface):
@@ -38,7 +62,7 @@ class CalendarWidget(WidgetInterface):
         self,
         calendar_service,
         view_mode="adaptive",
-        available_height=350,
+        available_height=DEFAULT_HEIGHT,
         start_offset_days=0,
         show_header=True,
         show_locations=False,
@@ -60,8 +84,8 @@ class CalendarWidget(WidgetInterface):
         self.calendar_service = calendar_service
         self.view_mode = view_mode
         self.show_locations = show_locations
-        self.padding = 20
-        self.width = 480
+        self.padding = DEFAULT_PADDING
+        self.width = DEFAULT_WIDTH
         self.available_height = available_height
         self.height = available_height
         self.events_per_day = events_per_day
@@ -159,20 +183,20 @@ class CalendarWidget(WidgetInterface):
 
         # Adaptive sizing based on event count
         if total_events <= EVENTS_THRESHOLD_SMALL:
-            font_size_event = 14
-            font_size_header = 15
-            line_height = 20
-            spacing_between_days = 16
+            font_size_event = FONT_SIZE_EVENT_LARGE
+            font_size_header = FONT_SIZE_HEADER_LARGE
+            line_height = LINE_HEIGHT_COMFORTABLE
+            spacing_between_days = SPACING_COMFORTABLE
         elif total_events <= EVENTS_THRESHOLD_MEDIUM:
-            font_size_event = 13
-            font_size_header = 14
-            line_height = 18
-            spacing_between_days = 14
+            font_size_event = FONT_SIZE_EVENT_MEDIUM
+            font_size_header = FONT_SIZE_HEADER_MEDIUM
+            line_height = LINE_HEIGHT_NORMAL
+            spacing_between_days = SPACING_MEDIUM
         else:
-            font_size_event = 12
-            font_size_header = 13
-            line_height = 16
-            spacing_between_days = 12
+            font_size_event = FONT_SIZE_EVENT_SMALL
+            font_size_header = FONT_SIZE_HEADER_SMALL
+            line_height = LINE_HEIGHT_COMPACT
+            spacing_between_days = SPACING_COMPACT
 
         # PRE-CALCULATE total height needed for all days WITH EVENTS
         total_height_needed = self.padding  # Start with top padding
@@ -1011,7 +1035,7 @@ class CalendarWidget(WidgetInterface):
         # Time until (right-aligned)
         if time_until_text:
             display.draw_text(
-                x_pos=x + 350,
+                x_pos=x + DEFAULT_HEIGHT,
                 y_pos=y_offset,
                 text=time_until_text,
                 font_size=10,

--- a/src/widgets/calendar_widget.py
+++ b/src/widgets/calendar_widget.py
@@ -6,6 +6,10 @@ from typing import List, Dict, Tuple
 from src.display.display_interface import DisplayInterface
 from src.widgets.widget_interface import WidgetInterface
 
+EVENTS_THRESHOLD_MEDIUM = 12
+
+EVENTS_THRESHOLD_SMALL = 6
+
 
 class CalendarWidget(WidgetInterface):
     """
@@ -154,12 +158,12 @@ class CalendarWidget(WidgetInterface):
         total_events = len(events)
 
         # Adaptive sizing based on event count
-        if total_events <= 6:
+        if total_events <= EVENTS_THRESHOLD_SMALL:
             font_size_event = 14
             font_size_header = 15
             line_height = 20
             spacing_between_days = 16
-        elif total_events <= 12:
+        elif total_events <= EVENTS_THRESHOLD_MEDIUM:
             font_size_event = 13
             font_size_header = 14
             line_height = 18


### PR DESCRIPTION
## What Changed
- Extracted magic numbers to module-level constants
- Added `EVENTS_THRESHOLD_SMALL` (6) and `EVENTS_THRESHOLD_MEDIUM` (12)
- Added font size constants (`FONT_SIZE_LARGE_EVENT`, etc.)
- Added line height constants (`LINE_HEIGHT_COMFORTABLE`, etc.)
- Added spacing constants (`SPACING_COMFORTABLE`, etc.)

## Why
- Hard-coded numbers like `6`, `12`, `14` had no context
- Makes code more readable and maintainable
- Easy to adjust layout settings in one place
- Follows Python naming conventions (PEP 8)

## Testing
✅ Tested locally - calendar displays correctly
✅ No functional changes - purely refactoring
✅ All existing functionality works

## Part of
Refactoring effort to simplify `calendar_widget.py`